### PR TITLE
Refactor SW: Add Workbox with stale-while-revalidate

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,5 @@
 # 📦 CHANGELOG
 
-## [v4] - 2025-06-22
-
 ## [v5.0.0-beta] - 2025-06-22
 ### Added
 - navigator.share() with clipboard fallback and toast message
@@ -14,6 +12,8 @@
 - Workbox cache strategy
 - Open Graph / Twitter meta tags
 - Contact form integration via Zapier
+
+## [v4] - 2025-06-22
 
 ### ✨ Added
 - 🌍 Multilingual toggle system via `[data-set-lang]` and `[data-lang]`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [v4] - 2025-06-22
 
+## [v5.0.0-beta] - 2025-06-22
+### Added
+- navigator.share() with clipboard fallback and toast message
+- GoatCounter analytics for Share button
+- Offline-capable APK with manifest+icons
+- Subtle redesign of topbar and language toggles
+- QR code section and image display improvements
+
+### Upcoming
+- Workbox cache strategy
+- Open Graph / Twitter meta tags
+- Contact form integration via Zapier
+
 ### ✨ Added
 - 🌍 Multilingual toggle system via `[data-set-lang]` and `[data-lang]`.
 - 📲 PWA installability: `manifest.json`, icons, and service worker (`sw.js`).

--- a/docs/index.html
+++ b/docs/index.html
@@ -463,5 +463,17 @@
             </div>
         </section>
     </div>
+    <script type="module">
+        import { Workbox } from 'https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-window.prod.mjs';
+
+        if ('serviceWorker' in navigator) {
+            const wb = new Workbox('/sw.js');
+                wb.addEventListener('waiting', () => {
+                wb.messageSkipWaiting();
+            });
+
+            wb.register();
+        }
+    </script>
 </body>
 </html>

--- a/docs/js/sw.js
+++ b/docs/js/sw.js
@@ -1,51 +1,27 @@
-// File: docs/js/sw.js
+import { registerRoute } from 'workbox-routing';
+import { StaleWhileRevalidate } from 'workbox-strategies';
+import { precacheAndRoute } from 'workbox-precaching';
 
-const CACHE_NAME = "oref-info-v1";
-const urlsToCache = [
-  "./",
-  "./index.html",
-  "./css/main.css",
-  "./OREF-offline-v1.apk",
-  "./slides.pdf",
-  "./icons/icon-192.png",
-  "./icons/icon-512.png",
-  "./manifest.json"
-];
+precacheAndRoute([
+  { url: './', revision: null },
+  { url: './index.html', revision: null },
+  { url: './css/main.css', revision: null },
+  { url: './OREF-offline-v1.apk', revision: null },
+  { url: './slides.pdf', revision: null },
+  { url: './icons/icon-192.png', revision: null },
+  { url: './icons/icon-512.png', revision: null },
+  { url: './manifest.json', revision: null },
+]);
 
-self.addEventListener("install", (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => {
-      return cache.addAll(urlsToCache);
-    })
-  );
-});
+// HTML pages: stale-while-revalidate
+registerRoute(
+  ({ request }) => request.destination === 'document',
+  new StaleWhileRevalidate()
+);
 
-self.addEventListener("activate", (event) => {
-  event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames.map((cacheName) => {
-          if (cacheName !== CACHE_NAME) {
-            return caches.delete(cacheName);
-          }
-        })
-      );
-    })
-  );
-});
-
-self.addEventListener("fetch", (event) => {
-  event.respondWith(
-    fetch(event.request)
-      .then((response) => {
-        const responseClone = response.clone();
-        caches.open(CACHE_NAME).then((cache) => {
-          cache.put(event.request, responseClone);
-        });
-        return response;
-      })
-      .catch(() => {
-        return caches.match(event.request);
-      })
-  );
-});
+// Static assets (CSS/JS/images)
+registerRoute(
+  ({ request }) =>
+    ['style', 'script', 'image'].includes(request.destination),
+  new StaleWhileRevalidate()
+);


### PR DESCRIPTION
### Summary

Replaced custom `sw.js` with a Workbox-based service worker.

### Changes

- Added `workbox-window` in `index.html` for registration
- Integrated `precacheAndRoute()` for static assets
- Added runtime routes for:
  - `document` requests (HTML) with `StaleWhileRevalidate`
  - `style`, `script`, `image` with `StaleWhileRevalidate`
- Enabled `messageSkipWaiting()` on `waiting` state

### Notes

- CDN-based Workbox v6.5.4 for now
- `revision: null` used to avoid cache conflicts (will optimize later)
- `wb.register()` is async-safe

No user-visible changes; improves cache strategy and maintainability.

